### PR TITLE
Add dynamic config

### DIFF
--- a/imageroot/actions/create-module/20configure
+++ b/imageroot/actions/create-module/20configure
@@ -49,25 +49,3 @@ response = agent.tasks.run(
 
 # Check if traefik configuration has been successfull
 agent.assert_exp(response['exit_code'] == 0)
-
-# Setup default scraping for local node
-rdb = agent.redis_connect()
-default_instance = rdb.get(f'node/{os.environ["NODE_ID"]}/default_instance/node_exporter')  or "node_exporter1"
-node_path = rdb.hget(f'module/{default_instance}/environment', 'NODE_EXPORTER_PATH') or "/metrics"
-
-# Read loki config from local node
-logcli = agent.read_envfile("/etc/nethserver/logcli.env")
-
-with open('prometheus.yml', 'w') as fp:
-    fp.write("global:\n")
-    fp.write("scrape_configs:\n")
-    fp.write('  - job_name: "node"\n')
-    fp.write(f'    metrics_path: "{node_path}"\n')
-    fp.write('    static_configs:\n')
-    fp.write('      - targets: ["10.0.2.2"]\n')
-    fp.write('  - job_name: "loki"\n')
-    fp.write('    basic_auth:\n')
-    fp.write(f'      username: "{logcli["LOKI_USERNAME"]}"\n')
-    fp.write(f'      password: "{logcli["LOKI_PASSWORD"]}"\n')
-    fp.write('    static_configs:\n')
-    fp.write(f'      - targets: ["{logcli["LOKI_ADDR"].removeprefix("http://")}"]\n')

--- a/imageroot/bin/update-config
+++ b/imageroot/bin/update-config
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import agent
+import os.path
+import agent.tasks
+
+# Setup default scraping for local node
+rdb = agent.redis_connect()
+default_instance = rdb.get(f'node/{os.environ["NODE_ID"]}/default_instance/node_exporter')  or "node_exporter1"
+node_path = rdb.hget(f'module/{default_instance}/environment', 'NODE_EXPORTER_PATH') or "/metrics"
+
+# Read loki config from local node
+logcli = agent.read_envfile("/etc/nethserver/logcli.env")
+
+with open('prometheus.yml', 'w') as fp:
+    fp.write("global:\n")
+    fp.write("scrape_configs:\n")
+    fp.write('  - job_name: "node"\n')
+    fp.write(f'    metrics_path: "{node_path}"\n')
+    fp.write('    static_configs:\n')
+    fp.write('      - targets: ["10.0.2.2"]\n')
+    fp.write('  - job_name: "loki"\n')
+    fp.write('    basic_auth:\n')
+    fp.write(f'      username: "{logcli["LOKI_USERNAME"]}"\n')
+    fp.write(f'      password: "{logcli["LOKI_PASSWORD"]}"\n')
+    fp.write('    static_configs:\n')
+    fp.write(f'      - targets: ["{logcli["LOKI_ADDR"].removeprefix("http://")}"]\n')
+
+    # Search for extra jobs
+
+    for jkey in rdb.scan_iter('module/{os.environ["MODULE_ID"}/jobs/*'):
+        job = jkey.removeprefix('module/{os.environ["MODULE_ID"}/jobs/')
+        config = rdb.hgetall(jkey)
+        fp.write(f'  - job_name: "{job}"\n')
+        fp.write(f'    metrics_path: "{config["metrics_path"]}"\n')
+        fp.write('    static_configs:\n')
+        fp.write(f'      - targets: ["{config["targets"]}"]\n')

--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -11,6 +11,7 @@ EnvironmentFile=%S/state/environment
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/prometheus.pid %t/prometheus.ctr-id
+ExecStartPre=runagent update-config
 ExecStart=/usr/bin/podman run \
     --detach \
     --conmon-pidfile=%t/prometheus.pid \


### PR DESCRIPTION
TODO:

- [ ] make it really dynamic: prometheus should reload the config every 5 minutes: maybe it's not possible because we need different authentications for different targets so we must create a job for each target. As an alternative, create and event that restarts prometheus. See also [link1](https://webcache.googleusercontent.com/search?q=cache:tR-KHQilY6gJ:https://neilkillen.com/2020/11/30/prometheus-file-based-service-discovery/+&cd=3&hl=it&ct=clnk&gl=it&client=firefox-b-d) and [link2](https://groups.google.com/g/prometheus-users/c/QOk7V-3d7D0/m/ElKvGgNaAgAJ?pli=1)
- [ ] test it with multiple targets like Nextsecurity firewalls
- [ ] support extra options like basic authentication/bearer/tls config?