### PR TITLE
Updated Build Images

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -16,11 +16,11 @@ container=$(buildah from scratch)
 # Reuse existing nodebuilder-prometheus container, to speed up builds
 if ! buildah containers --format "{{.ContainerName}}" | grep -q nodebuilder-prometheus; then
     echo "Pulling NodeJS runtime..."
-    buildah from --name nodebuilder-prometheus -v "${PWD}:/usr/src:Z" docker.io/library/node:lts
+    buildah from --name nodebuilder-prometheus -v "${PWD}:/usr/src:Z" docker.io/library/node:18.13.0-alpine
 fi
 
 echo "Build static UI files with node..."
-buildah run nodebuilder-prometheus sh -c "cd /usr/src/ui && yarn install && yarn build"
+buildah run --env="NODE_OPTIONS=--openssl-legacy-provider" nodebuilder-prometheus sh -c "cd /usr/src/ui && yarn install && yarn build"
 
 # Add imageroot directory to the container image
 buildah add "${container}" imageroot /imageroot
@@ -30,7 +30,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@any:routeadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=quay.io/prometheus/prometheus:v2.34.0" \
+    --label="org.nethserver.images=quay.io/prometheus/prometheus:v2.37.5" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"
@@ -49,7 +49,7 @@ images+=("${repobase}/${reponame}")
 #
 
 #
-# Setup CI when pushing to Github. 
+# Setup CI when pushing to Github.
 # Warning! docker::// protocol expects lowercase letters (,,)
 if [[ -n "${CI}" ]]; then
     # Set output value for Github Actions

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2481,9 +2481,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001245"
-  resolved "https://registry.nlark.com/caniuse-lite/download/caniuse-lite-1.0.30001245.tgz?cache=0&sync_timestamp=1626238653626&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fcaniuse-lite%2Fdownload%2Fcaniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
-  integrity sha1-RblBu9gzyw+lOGH/K650azxspdQ=
+  version "1.0.30001447"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz"
+  integrity sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==
 
 carbon-components@10.30.0:
   version "10.30.0"


### PR DESCRIPTION
Fixed build issues with `--env="NODE_OPTIONS=--openssl-legacy-provider"` in node environment, while doing that I've fixed node version to LTS.
Also updated prometheus version to 2.37.5 (LTS)
