### PR TITLE
get-config: make sure to return a valid hostname

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -1,31 +1,17 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
-# http://www.nethesis.it - nethserver@nethesis.it
-#
-# This script is part of NethServer.
-#
-# NethServer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License,
-# or any later version.
-#
-# NethServer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NethServer.  If not, see COPYING.
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import json
 import sys
 import agent
-import socket
 import os
+import subprocess
 
-config = {"fqdn": socket.getfqdn(), "path": os.environ['PROMETHEUS_PATH']}
+host = subprocess.run(['hostname', '-f'], text=True, capture_output=True).stdout.strip()
+config = {"fqdn": host, "path": os.environ['PROMETHEUS_PATH']}
 
 json.dump(config, fp=sys.stdout)


### PR DESCRIPTION
Sometimes python can fail to correctly resolve local hostname.