### PR TITLE
read Loki conf from env file or from redis

### DIFF
--- a/imageroot/actions/create-module/20configure
+++ b/imageroot/actions/create-module/20configure
@@ -49,8 +49,19 @@ response = agent.tasks.run(
 # Check if traefik configuration has been successfull
 agent.assert_exp(response['exit_code'] == 0)
 
-# Read loki config from local node
-logcli = agent.read_envfile("/etc/nethserver/logcli.env")
+# Read loki config from local node env file or read it from redis
+path = "/etc/nethserver/logcli.env"
+if os.path.exists(path):
+    logcli = agent.read_envfile(path)
+else:
+    # we are not on the Leader
+    rdb = agent.redis_connect()
+    loki = rdb.get("cluster/default_instance/loki")
+    logcli = rdb.hgetall(f'module/{loki}/environment')
+    # we do not have exactly the same var name between redis and logcli.env
+    logcli["LOKI_ADDR"] = logcli["LOKI_ADDR"]+':'+logcli["LOKI_HTTP_PORT"]
+    logcli["LOKI_USERNAME"] = logcli['LOKI_API_AUTH_USERNAME']
+    logcli["LOKI_PASSWORD"] =  logcli['LOKI_API_AUTH_PASSWORD']
 
 with open('prometheus.yml', 'w', encoding='utf-8') as fp:
     fp.write("global:\n")

--- a/imageroot/actions/create-module/20configure
+++ b/imageroot/actions/create-module/20configure
@@ -49,35 +49,3 @@ response = agent.tasks.run(
 # Check if traefik configuration has been successfull
 agent.assert_exp(response['exit_code'] == 0)
 
-# Read loki config from local node env file or read it from redis
-path = "/etc/nethserver/logcli.env"
-if os.path.exists(path):
-    logcli = agent.read_envfile(path)
-else:
-    # we are not on the Leader
-    # This script must rely on local node resources to ensure service startup
-    # even if the leader node is not reachable: connect to local Redis
-    # replica.
-    rdb = agent.redis_connect(use_replica=True)
-    loki = rdb.get("cluster/default_instance/loki")
-    logcli = rdb.hgetall(f'module/{loki}/environment')
-    # we do not have exactly the same var name between redis and logcli.env
-    logcli["LOKI_ADDR"] = logcli["LOKI_ADDR"]+':'+logcli["LOKI_HTTP_PORT"]
-    logcli["LOKI_USERNAME"] = logcli['LOKI_API_AUTH_USERNAME']
-    logcli["LOKI_PASSWORD"] =  logcli['LOKI_API_AUTH_PASSWORD']
-
-with open('prometheus.yml', 'w', encoding='utf-8') as fp:
-    fp.write("global:\n")
-    fp.write("scrape_configs:\n")
-    fp.write('  - job_name: "loki"\n')
-    fp.write('    basic_auth:\n')
-    fp.write(f'      username: "{logcli["LOKI_USERNAME"]}"\n')
-    fp.write(f'      password: "{logcli["LOKI_PASSWORD"]}"\n')
-    fp.write('    static_configs:\n')
-    fp.write(f'      - targets: ["{logcli["LOKI_ADDR"].removeprefix("http://")}"]\n')
-    fp.write('  - job_name: "providers"\n')
-    fp.write('    file_sd_configs:\n')
-    fp.write('      - files:\n')
-    fp.write('        - "/prometheus/prometheus.d/*.yml"\n')
-
-agent.run_helper('mkdir', 'prometheus.d')

--- a/imageroot/actions/create-module/20configure
+++ b/imageroot/actions/create-module/20configure
@@ -55,7 +55,10 @@ if os.path.exists(path):
     logcli = agent.read_envfile(path)
 else:
     # we are not on the Leader
-    rdb = agent.redis_connect()
+    # This script must rely on local node resources to ensure service startup
+    # even if the leader node is not reachable: connect to local Redis
+    # replica.
+    rdb = agent.redis_connect(use_replica=True)
     loki = rdb.get("cluster/default_instance/loki")
     logcli = rdb.hgetall(f'module/{loki}/environment')
     # we do not have exactly the same var name between redis and logcli.env

--- a/imageroot/bin/reload_configuration
+++ b/imageroot/bin/reload_configuration
@@ -16,6 +16,25 @@ import agent
 redis_client = agent.redis_connect(use_replica=True)
 providers = agent.list_service_providers(redis_client, 'prometheus-metrics', 'http')
 
+loki = redis_client.get("cluster/default_instance/loki")
+logcli = redis_client.hgetall(f'module/{loki}/environment')
+# we want to build the loki address
+logcli["LOKI_ADDR"] = logcli["LOKI_ADDR"]+':'+logcli["LOKI_HTTP_PORT"]
+
+with open('prometheus.yml', 'w', encoding='utf-8') as fp:
+    fp.write("global:\n")
+    fp.write("scrape_configs:\n")
+    fp.write('  - job_name: "loki"\n')
+    fp.write('    basic_auth:\n')
+    fp.write(f'      username: "{logcli["LOKI_API_AUTH_USERNAME"]}"\n')
+    fp.write(f'      password: "{logcli["LOKI_API_AUTH_PASSWORD"]}"\n')
+    fp.write('    static_configs:\n')
+    fp.write(f'      - targets: ["{logcli["LOKI_ADDR"].removeprefix("http://")}"]\n')
+    fp.write('  - job_name: "providers"\n')
+    fp.write('    file_sd_configs:\n')
+    fp.write('      - files:\n')
+    fp.write('        - "/prometheus/prometheus.d/*.yml"\n')
+
 # Get validation file from bin directory
 with open('../bin/validation.json', 'r', encoding='utf-8') as file:
     schema = json.load(file)

--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -11,6 +11,7 @@ EnvironmentFile=%S/state/environment
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/prometheus.pid %t/prometheus.ctr-id
+ExecStartPre=/usr/bin/mkdir -vp %S/state/prometheus.d
 ExecStartPre=/usr/local/bin/runagent reload_configuration
 ExecStart=/usr/bin/podman run \
     --detach \


### PR DESCRIPTION
The documentation states that prometheus should be installed on the leader but it is not a requirement. Moreover we could have only one instance on the node.

https://ns8.nethserver.org/en/latest/metrics.html

on the leader we read from th env file but on worker we read from redis

https://trello.com/c/Uh9YjzQ3/385-prometheus-grafana-p1-cant-install-on-worker-nodes