### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -7,11 +7,11 @@ Description=Prometheus server
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/prometheus.pid %t/prometheus.ctr-id
-ExecStartPre=/usr/bin/mkdir -vp %S/state/prometheus.d
+ExecStartPre=/usr/bin/mkdir -vp %E/state/prometheus.d
 ExecStartPre=/usr/local/bin/runagent reload_configuration
 ExecStart=/usr/bin/podman run \
     --detach \
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --publish=127.0.0.1:${TCP_PORT}:9090 \
-    --volume=%S/state/prometheus.yml:/prometheus/prometheus.yml:z \
+    --volume=%E/state/prometheus.yml:/prometheus/prometheus.yml:z \
     --volume=./prometheus.d/:/prometheus/prometheus.d/:z \
     --volume=prometheus-data:/prometheus:z \
     ${PROMETHEUS_IMAGE} --web.external-url=/${PROMETHEUS_PATH}/


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host